### PR TITLE
Add initial Express backend skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
-# boxmindback
-boxmind backend
+# BoxMind Backend
+
+This is a minimal Express/TypeScript backend skeleton for the BoxMind project.
+
+## Development
+
+1. Install dependencies
+   ```bash
+   npm install
+   ```
+2. Configure environment variables in `.env` (DATABASE_URL, API_KEY)
+3. Generate Prisma client
+   ```bash
+   npx prisma generate
+   ```
+4. Start development server
+   ```bash
+   npm run dev
+   ```

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node'
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "boxmindback",
+  "version": "1.0.0",
+  "description": "boxmind backend",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "dev": "ts-node src/index.ts",
+    "test": "jest"
+  },
+  "type": "commonjs"
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,54 @@
+// Prisma schema for BoxMind
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id        String   @id @default(uuid())
+  email     String   @unique
+  createdAt DateTime @default(now())
+  boxes     Box[]
+}
+
+model Box {
+  id        String   @id @default(uuid())
+  userId    String
+  name      String
+  createdAt DateTime @default(now())
+  user      User     @relation(fields: [userId], references: [id])
+  items     Item[]
+}
+
+model Item {
+  id           String   @id @default(uuid())
+  boxId        String
+  name         String
+  category     String
+  imageUrl     String?
+  barcode      String?
+  purchaseDate DateTime?
+  expiryDate   DateTime?
+  lastUsedDate DateTime?
+  createdAt    DateTime @default(now())
+  box          Box      @relation(fields: [boxId], references: [id])
+  reminders    Reminder[]
+}
+
+model Reminder {
+  id         String   @id @default(uuid())
+  itemId     String
+  type       ReminderType
+  notifiedAt DateTime @default(now())
+  item       Item     @relation(fields: [itemId], references: [id])
+}
+
+enum ReminderType {
+  expiry
+  reorg
+}

--- a/src/controllers/boxController.ts
+++ b/src/controllers/boxController.ts
@@ -1,0 +1,27 @@
+import { Request, Response } from 'express';
+import { boxSchema } from '../validators/boxValidator';
+import { prisma } from '../prisma';
+
+export const createBox = async (req: Request, res: Response) => {
+  try {
+    const { userId, name } = boxSchema.parse(req.body);
+    const count = await prisma.box.count({ where: { userId } });
+    if (count >= 2) {
+      return res.status(400).json({ error: 'Box limit reached' });
+    }
+    const box = await prisma.box.create({ data: { userId, name } });
+    res.json({ boxId: box.id });
+  } catch (err: any) {
+    res.status(400).json({ error: err.message });
+  }
+};
+
+export const getBoxes = async (req: Request, res: Response) => {
+  try {
+    const userId = boxSchema.shape.userId.parse(req.params.userId);
+    const boxes = await prisma.box.findMany({ where: { userId } });
+    res.json(boxes);
+  } catch (err: any) {
+    res.status(400).json({ error: err.message });
+  }
+};

--- a/src/controllers/insightController.ts
+++ b/src/controllers/insightController.ts
@@ -1,0 +1,13 @@
+import { Request, Response } from 'express';
+import { generateInsights } from '../services/insight';
+import { z } from 'zod';
+
+export const getInsights = async (req: Request, res: Response) => {
+  try {
+    const userId = z.string().uuid().parse(req.params.userId);
+    const data = await generateInsights(userId);
+    res.json(data);
+  } catch (err: any) {
+    res.status(400).json({ error: err.message });
+  }
+};

--- a/src/controllers/itemController.ts
+++ b/src/controllers/itemController.ts
@@ -1,0 +1,27 @@
+import { Request, Response } from 'express';
+import { itemSchema } from '../validators/itemValidator';
+import { prisma } from '../prisma';
+
+export const createItem = async (req: Request, res: Response) => {
+  try {
+    const data = itemSchema.parse(req.body);
+    const count = await prisma.item.count({ where: { boxId: data.boxId } });
+    if (count >= 50) {
+      return res.status(400).json({ error: 'Item limit reached' });
+    }
+    const item = await prisma.item.create({ data });
+    res.json({ itemId: item.id });
+  } catch (err: any) {
+    res.status(400).json({ error: err.message });
+  }
+};
+
+export const getItems = async (req: Request, res: Response) => {
+  try {
+    const boxId = itemSchema.shape.boxId.parse(req.params.boxId);
+    const items = await prisma.item.findMany({ where: { boxId } });
+    res.json(items);
+  } catch (err: any) {
+    res.status(400).json({ error: err.message });
+  }
+};

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -1,0 +1,13 @@
+import { Request, Response } from 'express';
+import { registerSchema } from '../validators/userValidator';
+import { prisma } from '../prisma';
+
+export const registerUser = async (req: Request, res: Response) => {
+  try {
+    const { email } = registerSchema.parse(req.body);
+    const user = await prisma.user.create({ data: { email } });
+    res.json({ userId: user.id });
+  } catch (err: any) {
+    res.status(400).json({ error: err.message });
+  }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,15 @@
+import express from 'express';
+import routes from './routes';
+import { apiKeyAuth } from './middleware/auth';
+import { errorHandler } from './middleware/errorHandler';
+
+const app = express();
+app.use(express.json());
+app.use(apiKeyAuth);
+app.use('/api', routes);
+app.use(errorHandler);
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,0 +1,9 @@
+import { Request, Response, NextFunction } from 'express';
+
+export const apiKeyAuth = (req: Request, res: Response, next: NextFunction) => {
+  const key = req.headers['x-api-key'];
+  if (key !== process.env.API_KEY) {
+    return res.status(401).json({ error: 'Invalid API key' });
+  }
+  next();
+};

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -1,0 +1,6 @@
+import { Request, Response, NextFunction } from 'express';
+
+export const errorHandler = (err: any, req: Request, res: Response, next: NextFunction) => {
+  console.error(err);
+  res.status(500).json({ error: 'Internal Server Error' });
+};

--- a/src/prisma.ts
+++ b/src/prisma.ts
@@ -1,0 +1,2 @@
+import { PrismaClient } from '@prisma/client';
+export const prisma = new PrismaClient();

--- a/src/routes/box.ts
+++ b/src/routes/box.ts
@@ -1,0 +1,7 @@
+import { Router } from 'express';
+import { createBox, getBoxes } from '../controllers/boxController';
+
+const router = Router();
+router.post('/', createBox);
+router.get('/:userId', getBoxes);
+export default router;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+import registerRoute from './register';
+import boxRoute from './box';
+import itemRoute from './item';
+import insightRoute from './insight';
+
+const router = Router();
+router.use(registerRoute);
+router.use('/box', boxRoute);
+router.use('/item', itemRoute);
+router.use('/insights', insightRoute);
+
+export default router;

--- a/src/routes/insight.ts
+++ b/src/routes/insight.ts
@@ -1,0 +1,6 @@
+import { Router } from 'express';
+import { getInsights } from '../controllers/insightController';
+
+const router = Router();
+router.get('/:userId', getInsights);
+export default router;

--- a/src/routes/item.ts
+++ b/src/routes/item.ts
@@ -1,0 +1,7 @@
+import { Router } from 'express';
+import { createItem, getItems } from '../controllers/itemController';
+
+const router = Router();
+router.post('/', createItem);
+router.get('/:boxId', getItems);
+export default router;

--- a/src/routes/register.ts
+++ b/src/routes/register.ts
@@ -1,0 +1,6 @@
+import { Router } from 'express';
+import { registerUser } from '../controllers/userController';
+
+const router = Router();
+router.post('/register', registerUser);
+export default router;

--- a/src/services/ai.ts
+++ b/src/services/ai.ts
@@ -1,0 +1,4 @@
+export const recognizeItem = async (imageUrl?: string, barcode?: string) => {
+  // TODO: integrate Google Vision and OpenFoodFacts
+  return { name: 'Unknown', category: 'Unknown' };
+};

--- a/src/services/insight.ts
+++ b/src/services/insight.ts
@@ -1,0 +1,7 @@
+import { prisma } from '../prisma';
+
+export const generateInsights = async (userId: string) => {
+  const topItems = await prisma.$queryRaw`SELECT name FROM items WHERE user_id=${userId} ORDER BY purchase_date LIMIT 5`;
+  const unusedItems = await prisma.$queryRaw`SELECT name FROM items WHERE user_id=${userId} AND last_used_date < NOW() - INTERVAL '1 year'`;
+  return { topItems, unusedItems };
+};

--- a/src/services/reminder.ts
+++ b/src/services/reminder.ts
@@ -1,0 +1,9 @@
+import cron from 'node-cron';
+import { prisma } from '../prisma';
+
+export const startReminderJob = () => {
+  cron.schedule('0 8 * * *', async () => {
+    // TODO: check items and send email reminders
+    console.log('Running reminder job');
+  });
+};

--- a/src/validators/boxValidator.ts
+++ b/src/validators/boxValidator.ts
@@ -1,0 +1,2 @@
+import { z } from 'zod';
+export const boxSchema = z.object({ userId: z.string().uuid(), name: z.string().min(1) });

--- a/src/validators/itemValidator.ts
+++ b/src/validators/itemValidator.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+export const itemSchema = z.object({
+  boxId: z.string().uuid(),
+  name: z.string().min(1),
+  category: z.string().min(1),
+  imageUrl: z.string().url().optional(),
+  barcode: z.string().optional(),
+  purchaseDate: z.string().optional(),
+  expiryDate: z.string().optional(),
+  lastUsedDate: z.string().optional(),
+});

--- a/src/validators/userValidator.ts
+++ b/src/validators/userValidator.ts
@@ -1,0 +1,2 @@
+import { z } from 'zod';
+export const registerSchema = z.object({ email: z.string().email() });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold a TypeScript/Express backend
- implement basic controllers, routes, and middleware
- add Prisma schema for PostgreSQL
- stub AI and reminder services
- provide tsconfig, Jest config and README instructions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e96dd2b38832c9a61af263cf0706a